### PR TITLE
rotation prototype

### DIFF
--- a/main.c
+++ b/main.c
@@ -20,15 +20,11 @@ int main(void)
     /* edit: this is the current way of testing whether
        canvas allocation has failed or not for now */
     canvy = SR_NewCanvas(640, 480);
-    SR_Canvas imagetest = SR_ImageFileToCanvas("./TEST.BMP");
-
+    SR_Canvas imagetest = SR_ImageFileToCanvas("./PUCK.BMP");
+    SR_Canvas rotcanvas;
+	double speeen = 0.0;
+	
     // free(imagetest.pixels); imagetest.pixels = NULL;
-    SR_DrawRect(&canvy, SR_CreateRGBA(0, 0, 0, 255), 0, 0, 256, 256);
-    imagetest = SR_CanvasRotate(&imagetest, 0.7853982);
-    SR_MergeCanvasIntoCanvas(
-        &canvy, &imagetest,
-        0, 0,
-        255, SR_BLEND_ADDITIVE);
 
     if (!SR_CanvasIsValid(&canvy)) {
         status = 3;
@@ -143,7 +139,16 @@ event_loop:
         rand() % (canvy.height)
     );
     */
-
+	/* the */
+	speeen += .05;
+    SR_DrawRect(&canvy, SR_CreateRGBA(0, 0, 0, 255), 0, 0, 256, 256);
+    rotcanvas = SR_CanvasRotate(&imagetest, speeen);
+    SR_MergeCanvasIntoCanvas(
+        &canvy, &rotcanvas,
+        0, 0,
+        255, SR_BLEND_OVERLAY);
+    SR_DestroyCanvas(&rotcanvas);
+    
     /* update the canvas here, the rest is
        actually blitting it to the window */
     

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -272,13 +272,79 @@ SR_Canvas SR_CanvasRotate(
 	SR_Canvas *src,
 	double angle)
 {
+	//magic numbers warning
+	//modulo by 2pi
+	//multiply by 2/pi, same as dividing by pi/2
+	char quarter_turns = floor((angle % 6.28318530718) * 0.636619772368);
+	SR_Canvas temp0;
+	switch (quarter_turns) {
+		case 0:
+		default:
+			temp0 = SR_CopyCanvas(src, 0, 0, src->width, src->height);
+			break;
+		case 1:
+			temp0 = SR_CanvasRot90(src);
+			break;
+		case 2:
+			temp0 = SR_CanvasRot180(src);
+			break;
+		case 3:
+			temp0 = SR_CanvasRot270(src);
+			break;
+	}
+	
+	//modulo by pi/2
+	angle %= 1.57079632679;
 	double xshear = -tan(angle / 2) * (src-> height >> 1);
 	double yshear = sin(angle) * (src-> width >> 1);
 	
-	SR_Canvas temp0 = SR_CanvasYShear(src, xshear);
-	SR_Canvas temp1 = SR_CanvasXShear(&temp0, yshear);
+	SR_Canvas temp1 = SR_CanvasYShear(&temp0, xshear);
 	SR_DestroyCanvas(&temp0);
-	SR_Canvas final = SR_CanvasYShear(&temp1, xshear);
+	SR_Canvas temp2 = SR_CanvasXShear(&temp1, yshear);
 	SR_DestroyCanvas(&temp1);
+	SR_Canvas final = SR_CanvasYShear(&temp2, xshear);
+	SR_DestroyCanvas(&temp2);
+	return final;
+}
+
+SR_Canvas SR_CanvasRot90(SR_Canvas *src) {
+	unsigned short w = src->width;
+	unsigned short h = src->height;
+	SR_Canvas final = SR_NewCanvas(h, w);
+	SR_ZeroFill(&final);
+	for (unsigned short x = 0; x < w; x++) {
+		for (unsigned short y = 0; y < h; y++) {
+			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
+			SR_CanvasSetPixel(&final, h - y, x, pixel);
+		}
+	}
+	return final;
+}
+
+SR_Canvas SR_CanvasRot180(SR_Canvas *src) {
+	unsigned short w = src->width;
+	unsigned short h = src->height;
+	SR_Canvas final = SR_NewCanvas(w, h);
+	SR_ZeroFill(&final);
+	for (unsigned short x = 0; x < w; x++) {
+		for (unsigned short y = 0; y < h; y++) {
+			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
+			SR_CanvasSetPixel(&final, w - x, h - y, pixel);
+		}
+	}
+	return final;
+}
+
+SR_Canvas SR_CanvasRot270(SR_Canvas *src) {
+	unsigned short w = src->width;
+	unsigned short h = src->height;
+	SR_Canvas final = SR_NewCanvas(h, w);
+	SR_ZeroFill(&final);
+	for (unsigned short x = 0; x < w; x++) {
+		for (unsigned short y = 0; y < h; y++) {
+			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
+			SR_CanvasSetPixel(&final, y, w - x, pixel);
+		}
+	}
 	return final;
 }

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -235,13 +235,13 @@ SR_Canvas SR_CanvasXShear(
 	unsigned short ycenter = h >> 1;
 	double skew = (double)skew_amount / (double)ycenter;
 	skew_amount = abs(skew_amount);
-	SR_Canvas final = SR_NewCanvas(w + skew_amount << 1, h);
+	SR_Canvas final = SR_NewCanvas(w, h);
 	SR_ZeroFill(&final);
 	for (unsigned short y = 0; y < h; y++) {
 		int xshift = (y - ycenter) * skew;
 		for (unsigned short x = 0; x < w; x++) {
 			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
-			SR_CanvasSetPixel(&final, x + skew_amount + xshift, y, pixel);
+			SR_CanvasSetPixel(&final, x + xshift, y, pixel);
 		}
 	}
 	return final;
@@ -256,13 +256,13 @@ SR_Canvas SR_CanvasYShear(
 	unsigned short xcenter = w >> 1;
 	double skew = (double)skew_amount / (double)xcenter;
 	skew_amount = abs(skew_amount);
-	SR_Canvas final = SR_NewCanvas(w, h + skew_amount << 1);
+	SR_Canvas final = SR_NewCanvas(w, h);
 	SR_ZeroFill(&final);
 	for (unsigned short x = 0; x < w; x++) {
 		int yshift = (x - xcenter) * skew;
 		for (unsigned short y = 0; y < h; y++) {
 			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
-			SR_CanvasSetPixel(&final, x, y + skew_amount + yshift, pixel);
+			SR_CanvasSetPixel(&final, x, y + yshift, pixel);
 		}
 	}
 	return final;
@@ -272,13 +272,13 @@ SR_Canvas SR_CanvasRotate(
 	SR_Canvas *src,
 	double angle)
 {
-	double xshear = -sin(angle);
-	double yshear = tan(angle / 2);
+	double xshear = -tan(angle / 2) * (src-> height >> 1);
+	double yshear = sin(angle) * (src-> width >> 1);
 	
-	SR_Canvas temp0 = SR_CanvasXShear(src, xshear);
-	SR_Canvas temp1 = SR_CanvasYShear(&temp0, yshear);
+	SR_Canvas temp0 = SR_CanvasYShear(src, xshear);
+	SR_Canvas temp1 = SR_CanvasXShear(&temp0, yshear);
 	SR_DestroyCanvas(&temp0);
-	SR_Canvas final = SR_CanvasXShear(&temp1, xshear);
+	SR_Canvas final = SR_CanvasYShear(&temp1, xshear);
 	SR_DestroyCanvas(&temp1);
 	return final;
 }

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -275,7 +275,7 @@ SR_Canvas SR_CanvasRotate(
 	//magic numbers warning
 	//modulo by 2pi
 	//multiply by 2/pi, same as dividing by pi/2
-	char quarter_turns = floor((angle % 6.28318530718) * 0.636619772368);
+	char quarter_turns = floor(fmod(angle, 6.28318530718) * 0.636619772368);
 	SR_Canvas temp0;
 	switch (quarter_turns) {
 		case 0:
@@ -294,7 +294,7 @@ SR_Canvas SR_CanvasRotate(
 	}
 	
 	//modulo by pi/2
-	angle %= 1.57079632679;
+	angle = fmod(angle, 1.57079632679);
 	double xshear = -tan(angle / 2) * (src-> height >> 1);
 	double yshear = sin(angle) * (src-> width >> 1);
 	
@@ -315,7 +315,7 @@ SR_Canvas SR_CanvasRot90(SR_Canvas *src) {
 	for (unsigned short x = 0; x < w; x++) {
 		for (unsigned short y = 0; y < h; y++) {
 			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
-			SR_CanvasSetPixel(&final, h - y, x, pixel);
+			SR_CanvasSetPixel(&final, y, w - x, pixel);
 		}
 	}
 	return final;
@@ -343,7 +343,7 @@ SR_Canvas SR_CanvasRot270(SR_Canvas *src) {
 	for (unsigned short x = 0; x < w; x++) {
 		for (unsigned short y = 0; y < h; y++) {
 			SR_RGBAPixel pixel = SR_CanvasGetPixel(src, x, y);
-			SR_CanvasSetPixel(&final, y, w - x, pixel);
+			SR_CanvasSetPixel(&final, h - y, x, pixel);
 		}
 	}
 	return final;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -118,4 +118,10 @@
 	SR_Canvas SR_CanvasRotate(
 		SR_Canvas *src,
 		double angle);
+	
+	// Returns a canvas rotated 90, 180, or 270 degrees counter-clockwise
+	// Will malloc a new canvas!
+	SR_Canvas SR_CanvasRot90(SR_Canvas *src);
+	SR_Canvas SR_CanvasRot180(SR_Canvas *src);
+	SR_Canvas SR_CanvasRot270(SR_Canvas *src);
 #endif


### PR DESCRIPTION
rotation of canvas contents technically works now, but it works best with square canvases that have padding around their contents (exact minimum padding is sqrt(2) * width or height)